### PR TITLE
Update (fix) the url for the "leave page" website

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Here you will find an extensive list of useless (and funny) websites. I knew abo
 
 [Endless Horse](http://endless.horse/) - An astonishingly tall horse.
 
-[leave page](https://leavepage.anaurelian.com/) - Just leave the page and see the reaction.
+[leave page](https://leavepage.aurelitec.com/) - Just leave the page and see the reaction.
 
 ## Contributing guidelines
 


### PR DESCRIPTION
This fixes the broken url for the "leave page" website.

The new url is:
https://leavepage.aurelitec.com/