### PR TITLE
Add Prank My Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Here you will find an extensive list of useless (and funny) websites. I knew abo
 
 [leave page](https://leavepage.aurelitec.com/) - Just leave the page and see the reaction.
 
+[Prank My Face](https://prankmyface.lol/) - Create a fake AI face-twin finder link and prank a friend with the reveal.
+
 ## Contributing guidelines
 
 **If you wish to add more to this list, please read the [contribution guidelines](https://github.com/scriptex/awesome-useless-websites/blob/master/CONTRIBUTING.md).**
@@ -197,4 +199,3 @@ Support and sponsor my work:
 	<img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scriptex/scriptex/master/badges/shiba-inu.json" />
 </a>
 </div>
-


### PR DESCRIPTION
Adds Prank My Face to the useless/funny websites list.\n\nURL: https://prankmyface.lol/\n\nWhy it belongs: it is a funny interactive web prank that presents a fake AI face-twin finder, then reveals the joke and prompts the recipient to prank someone else.