### PR TITLE
Add Trynkit to Useless Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Here you will find an extensive list of useless (and funny) websites. I knew abo
 
 [crzy.site](https://crzy.site/) - A growing collection of absolutely pointless single-page websites. Each one dumber than the last.
 
+[Trynkit](https://pongvn.com/trynkit/) - A grab-bag of silly toys — meme makers, novelty love/zodiac "calculators" and quizzes to spam in the group chat.
+
 ## Contributing guidelines
 
 **If you wish to add more to this list, please read the [contribution guidelines](https://github.com/scriptex/awesome-useless-websites/blob/master/CONTRIBUTING.md).**


### PR DESCRIPTION
Adds **Trynkit** (https://pongvn.com/trynkit/) to the Useless Websites list.

Why it fits: a grab-bag of pointless-but-fun little toys — meme makers, novelty "calculators" (love %, ship names, zodiac match) and silly quizzes made to share in the group chat. No real purpose beyond a laugh, which felt right at home here.

- Tested & live
- Individual PR for this one suggestion
- Placement & format per CONTRIBUTING (bottom of the category, `[Name](link) - Description.`)

Disclosure: I'm the maker (Pong Studio). Happy to tweak the wording — thanks for curating this list!
